### PR TITLE
Alterar import de dependencias para usar somente impressao  da DANFE. Corrigir tamanho do campo do CNPJ do transportador na DANFE retrato

### DIFF
--- a/pysignfe/nfe/danfe/danferetrato.py
+++ b/pysignfe/nfe/danfe/danferetrato.py
@@ -670,12 +670,12 @@ class TransporteRetrato(BandaDANFE):
         self.inclui_descritivo(nome='clc', titulo=u'TRANSPORTADOR/VOLUMES TRANSPORTADOS', top=0*cm, left=0*cm, width=19.4*cm)
 
         # 1ª linha
-        lbl, fld = self.inclui_campo(nome='trn_nome', titulo=u'NOME/RAZÃO SOCIAL', conteudo='NFe.infNFe.transp.transporta.xNome.valor', top=0.42*cm, left=0*cm, width=9.55*cm)
-        lbl, fld = self.inclui_campo(nome='trn_frete', titulo=u'FRETE POR CONTA', conteudo='NFe.frete_formatado', top=0.42*cm, left=9.55*cm, width=2.8*cm)
-        lbl, fld = self.inclui_campo(nome='trn_antt', titulo=u'CÓDIGO ANTT', conteudo='NFe.infNFe.transp.veicTransp.RNTC.valor', top=0.42*cm, left=12.35*cm, width=1.5*cm)
-        lbl, fld = self.inclui_campo(nome='trn_placa', titulo=u'PLACA DO VEÍCULO', conteudo=u'NFe.placa_veiculo_formatada', top=0.42*cm, left=13.85*cm, width=1.85*cm)
-        lbl, fld = self.inclui_campo(nome='trn_vei_uf', titulo=u'UF', conteudo='NFe.infNFe.transp.veicTransp.UF.valor', top=0.42*cm, left=15.7*cm, width=0.7*cm)
-        lbl, fld = self.inclui_campo(nome='trn_cnpj', titulo=u'CNPJ/CPF', conteudo=u'NFe.cnpj_transportadora_formatado', top=0.42*cm, left=16.4*cm, width=3*cm, margem_direita=True)
+        lbl, fld = self.inclui_campo(nome='trn_nome', titulo=u'NOME/RAZÃO SOCIAL', conteudo='NFe.infNFe.transp.transporta.xNome.valor', top=0.42*cm, left=0*cm, width=9.02*cm)
+        lbl, fld = self.inclui_campo(nome='trn_frete', titulo=u'FRETE POR CONTA', conteudo='NFe.frete_formatado', top=0.42*cm, left=9.02*cm, width=2.8*cm)
+        lbl, fld = self.inclui_campo(nome='trn_antt', titulo=u'CÓDIGO ANTT', conteudo='NFe.infNFe.transp.veicTransp.RNTC.valor', top=0.42*cm, left=11.82*cm, width=1.5*cm)
+        lbl, fld = self.inclui_campo(nome='trn_placa', titulo=u'PLACA DO VEÍCULO', conteudo=u'NFe.placa_veiculo_formatada', top=0.42*cm, left=13.32*cm, width=1.85*cm)
+        lbl, fld = self.inclui_campo(nome='trn_vei_uf', titulo=u'UF', conteudo='NFe.infNFe.transp.veicTransp.UF.valor', top=0.42*cm, left=15.17*cm, width=0.7*cm)
+        lbl, fld = self.inclui_campo(nome='trn_cnpj', titulo=u'CNPJ/CPF', conteudo=u'NFe.cnpj_transportadora_formatado', top=0.42*cm, left=15.87*cm, width=3.53*cm, margem_direita=True)
 
         # 2ª linha
         lbl, fld = self.inclui_campo(nome='trn_end', titulo=u'ENDEREÇO', conteudo='NFe.infNFe.transp.transporta.xEnder.valor', top=1.12*cm, left=0*cm, width=9.75*cm)

--- a/pysignfe/nfe/processador_nfe.py
+++ b/pysignfe/nfe/processador_nfe.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from http.client import HTTPSConnection, HTTPResponse
 #from OpenSSL import crypto
 import socket
 import ssl
@@ -74,18 +73,6 @@ class ProcessoNFe(object):
         self.webservice = webservice
         self.envio = envio
         self.resposta = resposta
-
-class ConexaoHTTPS(HTTPSConnection):
-    def connect(self):
-        "Connect to a host on a given (SSL) port."
-
-        sock = socket.create_connection((self.host, self.port),
-                                        self.timeout, self.source_address)
-        if self._tunnel_host:
-            self.sock = sock
-            self._tunnel()
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                                    ssl_version=ssl.PROTOCOL_SSLv3)
 
 
 class ProcessadorNFe(object):
@@ -177,6 +164,7 @@ class ProcessadorNFe(object):
         
         print("  servidor: ", self._servidor)
         print("  url: ", self._url)
+        from http.client import HTTPSConnection
         con = HTTPSConnection(self._servidor, key_file=nome_arq_chave, cert_file=nome_arq_certificado)
         #con = ConexaoHTTPS(self._servidor, key_file=nome_arq_chave, cert_file=nome_arq_certificado)
         con.request(u'POST', u'/' + self._url, self._soap_envio.xml.encode(u'utf-8'), self._soap_envio.header)

--- a/pysignfe/xml_sped/certificado.py
+++ b/pysignfe/xml_sped/certificado.py
@@ -5,10 +5,6 @@ from datetime import datetime
 from pysignfe.xml_sped import *
 import lxml
 
-##Modificado para utilizar o signxml ao inves do libxml2 e xmlsec
-from signxml import XMLSigner, XMLVerifier
-from signxml import methods
-
 
 class Certificado(object):
     def __init__(self):
@@ -127,6 +123,10 @@ class Certificado(object):
         return chave_de_acesso
         
     def assina_xml(self, xml):
+        ##Modificado para utilizar o signxml ao inves do libxml2 e xmlsec
+        from signxml import XMLSigner
+        from signxml import methods
+
         xml = self._prepara_doc_xml(xml)
         doc_xml = lxml.etree.fromstring(xml.encode('utf-8'))
         


### PR DESCRIPTION
Algumas dependencias que não são necessárias para imprimir a DANFE podem ser importadas apenas onde forem usadas, permitindo usar o recurso de impressão sem precisar instalar tais dependencias