### PR TITLE
Correção do nome da tag da data de emissão na impressão da DANFE

### DIFF
--- a/pysignfe/nfe/processador_nfe.py
+++ b/pysignfe/nfe/processador_nfe.py
@@ -1247,7 +1247,7 @@ class DANFE(object):
             if (self.NFe.infNFe.ide.indPag.valor == 1) or \
                 (len(self.NFe.infNFe.cobr.dup) > 1) or \
                 ((len(self.NFe.infNFe.cobr.dup) == 1) and \
-                (self.NFe.infNFe.cobr.dup[0].dVenc.xml > self.NFe.infNFe.ide.dEmi.xml)):
+                (self.NFe.infNFe.cobr.dup[0].dVenc.xml > self.NFe.infNFe.ide.dhEmi.xml)):
 
                 if self.imprime_duplicatas:
                     self.danfe.fatura_a_prazo.elements.append(self.danfe.duplicatas)


### PR DESCRIPTION
Nas verificações para definir o tipo de pagamento a tag utilizada na
comparação era 'dEmi', mas a correta é 'dhEmi'. Isso estava fazendo com que fosse impresso PAGAMENTO A PRAZO mesmo quando era a vista.