### PR TITLE
Consertar cálculo do timezone no Python3

### DIFF
--- a/pysignfe/xml_sped/base.py
+++ b/pysignfe/xml_sped/base.py
@@ -1015,7 +1015,7 @@ def somente_ascii(funcao):
     
     
 def fuso_horario_sistema():
-    diferenca = timezone / -3600
+    diferenca = timezone // -3600
 
     if diferenca < 0:
         return pytz.timezone('Etc/GMT+' + str(diferenca * -1))


### PR DESCRIPTION
No commit anterior foi introduzida uma divisão utilizando '/', que possui
comportamentos diferentes entre o python3 e python2. Utilizar '//', divisão
inteira, resolve o problema.